### PR TITLE
add support for airspy graphs in tar1090

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ It will provide BEAST protocol on TCP port `30005`.
 | `AIRSPY_ADSB_BIAS_TEE` | `-b` | Set to `true` to enable Bias-Tee | *unset* |
 | `AIRSPY_ADSB_BIT_PACKING` | `-p` | Set to `true` to enable Bit Packing | *unset* |
 | `AIRSPY_ADSB_VERBOSE` | `-v` | Enable Verbose mode | *unset* |
+| `AIRSPY_ADSB_STATS` | `-S` | Set to `true` to enable statistics in `/run/airspy_adsb` (this needs to be shared with a `tar1090` instance) | *unset* |
 | `AIRSPY_ADSB_ARCH` | N/A | Forces a specific architecture binary. Supports `arm64`, `armv7`, `arm`, `nehalem`, `x86_64` or `i386`. If unset, will auto-detect. | *unset* |
 
 ## Using with `readsb`

--- a/rootfs/etc/services.d/airspy_adsb/run
+++ b/rootfs/etc/services.d/airspy_adsb/run
@@ -106,6 +106,11 @@ if [[ "${AIRSPY_ADSB_VERBOSE^^}" == "TRUE" ]]; then
     AIRSPY_ADSB_CMD+=("-v")
 fi
 
+# Handle "-S"
+if [[ "${AIRSPY_ADSB_STATS^^}" == "TRUE" ]]; then
+    AIRSPY_ADSB_CMD+=("-S" "/run/airspy_adsb/stats.json")
+fi
+
 # Handle architecture
 if [[ -z "$AIRSPY_ADSB_ARCH" ]]; then
 


### PR DESCRIPTION
The '-S' flag isn't documented in the '-h' output of the airspy app, but it is implemented and makes nice graphs - assuming you share the magic directory with a tar1090 instance.