### PR TITLE
fix airspy_adsb service not stopping correctly

### DIFF
--- a/rootfs/etc/s6-overlay/scripts/airspy_adsb
+++ b/rootfs/etc/s6-overlay/scripts/airspy_adsb
@@ -142,7 +142,7 @@ if [[ -z "$AIRSPY_ADSB_ARCH" ]]; then
 
     else
         "${s6wrap[@]}" echo "ERROR: Unsupported architecture: $(uname -m)!"
-        sleep infinity
+        exec sleep infinity
     fi
 fi
 
@@ -152,21 +152,24 @@ AIRSPY_ADSB_BIN="/usr/local/bin/airspy_adsb.${AIRSPY_ADSB_ARCH}"
 # Ensure binary exists
 if [[ ! -x "$AIRSPY_ADSB_BIN" ]]; then
     "${s6wrap[@]}" echo "ERROR: Executable binary not found for architecture: $AIRSPY_ADSB_ARCH!"
-        sleep infinity
+    exec sleep infinity
 fi
 
 # Ensure binary runnable
 if ! "$AIRSPY_ADSB_BIN" -h > /dev/null 2>&1; then
     "${s6wrap[@]}" echo "ERROR: Executable $AIRSPY_ADSB_ARCH binary not supported on $(uname -m) architecture!"
-        sleep infinity
+    exec sleep infinity
 fi
 
 # Execute binary with arguments prepared above
 "${s6wrap[@]}" echo "Running $AIRSPY_ADSB_ARCH binary on $(uname -m) architecture."
 "${s6wrap[@]}" echo "Running: ${AIRSPY_ADSB_BIN} ${AIRSPY_ADSB_CMD[*]}"
 
-#shellcheck disable=SC2016
-"${s6wrap[@]}" "${AIRSPY_ADSB_BIN}" "${AIRSPY_ADSB_CMD[@]}"
-
 # Slow down restarts
-sleep 10
+sleep 10 &
+
+#shellcheck disable=SC2016
+"${s6wrap[@]}" "${AIRSPY_ADSB_BIN}" "${AIRSPY_ADSB_CMD[@]}" &
+
+# trap will only work properly while the shell is running / waiting, not while another program is being foreground executed
+wait || true


### PR DESCRIPTION
The 'trap ... pkill ...' in the service script doesn't work, making s6 wait for the service indefinitely.  This in turn runs into the 10 second docker stop / compose down timeout which will send a SIGKILL to the whole container leading to ungraceful termination.

The trap will only work when there is no foreground program being executed by the shell, it does work however during a wait.

Start airspy_adsb in the background and issue wait. Run the sleep delay in the background as well so we don't need to wait for it when the trap pkill happens. Should airspy_adsb error, the wait should limit program starts to every 10 seconds.