### PR TITLE
fixup nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ghcr.io/sdr-enthusiasts/docker-baseimage:base
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # hadolint ignore=DL3008,DL3003,SC1091
 RUN set -x && \
   #

--- a/rootfs/etc/nginx/nginx.conf
+++ b/rootfs/etc/nginx/nginx.conf
@@ -21,7 +21,7 @@ http {
     server {
         server_name     _;
         listen          80 default_server;
-        root            /var/www/html
+        root            /var/www/html;
 
         error_page    500 502 503 504  /50x.html;
 

--- a/rootfs/etc/s6-overlay/scripts/airspy_adsb
+++ b/rootfs/etc/s6-overlay/scripts/airspy_adsb
@@ -173,4 +173,5 @@ sleep 10 &
 "${s6wrap[@]}" "${AIRSPY_ADSB_BIN}" "${AIRSPY_ADSB_CMD[@]}" &
 
 # trap will only work properly while the shell is running / waiting, not while another program is being foreground executed
-wait || true
+# the first wait exits due to the signal which is trapped, the 2nd wait actually waits for collectd to exit
+wait || wait || true


### PR DESCRIPTION
fix nginx by moving config into the right spot.
fix airspy_adsb wait logic so the service ACTUALLY waits for airspy_adsb to exit before the service is done stopping.