### PR TITLE
ci: drop redundant hadolint job from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,20 +31,9 @@ jobs:
           echo "Workflow dispatch reason: $INPUTS_REASON"
           echo "Use test image: $INPUTS_USE_TEST_IMAGE"
 
-  hadolint:
-    name: Run hadolint against docker files
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Pull hadolint/hadolint:latest Image
-        run: docker pull hadolint/hadolint:latest
-      - name: Run hadolint against Dockerfiles
-        run: docker run --rm -i -v "$PWD":/workdir --workdir /workdir --entrypoint hadolint hadolint/hadolint --ignore DL3003 --ignore DL3006 --ignore DL3010 --ignore DL4001 --ignore DL3007 --ignore DL3008 --ignore SC2068 --ignore DL3007 --ignore SC1091 --ignore DL3013 --ignore DL3010  --ignore SC3054 $(find . -type f -iname "Dockerfile*")
-
   build_and_push:
     name: Image Build & Push
     uses: sdr-enthusiasts/common-github-workflows/.github/workflows/sdre.yml@d99ce7f631ca56901a4aecca25d5c6e4b0a7e2f1 # main
-    needs: [hadolint]
     with:
       push_enabled: true
       ghcr_repo_owner: ${{ github.repository_owner }}


### PR DESCRIPTION
## Problem

This job ran hadolint from unpinned `hadolint/hadolint:latest`, so it silently adopted upstream rule changes. hadolint v2.15.0 (published 2026-07-30T13:39:01Z) extended `DL3025` to fire on `HEALTHCHECK ... CMD` ([#1209](https://github.com/hadolint/hadolint/pull/1209)) and added `DL3064` — the breakage that has been working through this fleet.

This Dockerfile happens to be clean at 2.15.1 — its `HEALTHCHECK` is already in JSON exec form — so nothing was breaking here yet:

```console
$ hadolint --config <shared ruleset> Dockerfile   # 2.15.1
rc=0
```

`build_and_push` gated on the job via `needs: [hadolint]`, so a future rule change would have **blocked the image build outright**.

## Changes

Removes the `hadolint` job and the `needs: [hadolint]` reference.

Coverage is unchanged: `check_docker = true`, so `lint.yaml` already lints the Dockerfile on every PR via pre-commit against a `flake.lock`-pinned version.

### `--ignore SC3054` deliberately not carried over

The removed ignore list contained `--ignore SC3054`, which is historical evidence of a hadolint bug rather than a real finding. hadolint 2.15.x resets its shell-dialect tracking to POSIX sh when an `ARG`/`ENV` follows `SHELL`, so bash constructs in later `RUN`s misreport:

```dockerfile
FROM debian:trixie-slim
SHELL ["/bin/bash", "-o", "pipefail", "-c"]
ARG FOO="bar"
RUN P=() && P+=(nginx) && echo "${P[@]}"
```

```text
2.15.1 -> SC3054 warning: In POSIX sh, array references are undefined.
2.14.0 -> rc=0
```

The correct fix is reordering the instructions, as done in `docker-acarshub#1826` and `docker-aprs-tracker#67`. This Dockerfile does not trip it, and suppressing SC3054 anywhere would mask genuine POSIX-portability findings.

## Verification

```console
$ yq '.jobs | keys' .github/workflows/deploy.yml
- workflow-dispatch
- build_and_push

dangling needs: none
```

- `nix develop -c pre-commit run --all-files`: green, including `check-github-workflows` and `hadolint`
- No Dockerfile changes, so no image can be affected
- No hooks bypassed; no `--no-verify`
